### PR TITLE
Add new column refinement type taking string as parameter

### DIFF
--- a/src/Definitions.ts
+++ b/src/Definitions.ts
@@ -99,7 +99,7 @@ export type UploadTransformation<P> = (opts: UploadTransformationI<P>) => Promis
  * Interface used for defining refinement option
  */
 
-export type ColumnRefinementType = "single" | "double-column" | "to-iri";
+export type ColumnRefinementType = "single" | "double-column" | "to-iri" | "single-param";
 
 /**
  * Define transformation scripts in configuration
@@ -118,8 +118,12 @@ export interface DoubleColumnRefinement extends BaseColumnRefinement {
   type: "double-column";
   transformation: (firstColumn: string, selectedColumn: string) => Promise<string | undefined>;
 }
+export interface SingleColumnParamRefinement extends BaseColumnRefinement {
+  type: "single-param";
+  transformation: (value: string, iriPrefix: string) => Promise<string | undefined>;
+}
 
-export type ColumnRefinement = SingleColumnRefinement | DoubleColumnRefinement;
+export type ColumnRefinement = SingleColumnRefinement | DoubleColumnRefinement | SingleColumnParamRefinement;
 
 export type ColumnRefinements = ColumnRefinement[];
 
@@ -138,6 +142,10 @@ interface DoubleColumnRefinementSetting extends BaseColumnRefinementSetting {
   type: "double-column";
   data: { secondColumnIdx: number };
 }
+interface SingleColumnParamRefinementSetting extends BaseColumnRefinementSetting {
+  type: "single-param";
+  data: { iriPrefix: string };
+}
 interface ToIriColumnRefinementSetting extends BaseColumnRefinementSetting {
   type: "to-iri";
   data: { iriPrefix: string };
@@ -145,4 +153,5 @@ interface ToIriColumnRefinementSetting extends BaseColumnRefinementSetting {
 export type ColumnRefinementSetting =
   | SingleColumnRefinementSetting
   | DoubleColumnRefinementSetting
+  | SingleColumnParamRefinementSetting
   | ToIriColumnRefinementSetting;

--- a/src/config/WizardConfig.ts
+++ b/src/config/WizardConfig.ts
@@ -8,7 +8,7 @@ export type TriplyDbReference = {
   label: string;
   link: string;
 };
-export type ColumnRefinementType = "single" | "double-column";
+export type ColumnRefinementType = "single" | "double-column" | "single-param";
 
 export interface BaseColumnRefinement {
   label: string;
@@ -24,7 +24,11 @@ export interface DoubleColumnRefinement extends BaseColumnRefinement {
   type: "double-column";
   transformation: (firstColumn: string, selectedColumn: string) => Promise<string | undefined>;
 }
-export type ColumnRefinement = SingleColumnRefinement | DoubleColumnRefinement;
+export interface SingleColumnParamRefinement extends BaseColumnRefinement {
+  type: "single-param";
+  transformation: (value: string, iriPrefix: string) => Promise<string | undefined>;
+}
+export type ColumnRefinement = SingleColumnRefinement | DoubleColumnRefinement | SingleColumnParamRefinement;
 export default interface WizardConfig {
   /**
    * Branding

--- a/src/containers/Configure/TransformationSelector.tsx
+++ b/src/containers/Configure/TransformationSelector.tsx
@@ -118,6 +118,12 @@ const TransformationSelector: React.FC<Props> = ({
                           selectedColumn === 0 ? 1 : 0,
                       },
                     });
+                  } else if (selectedTransformation.type === "single-param") {
+                    onTransformationChange({
+                      label: selectedTransformation.label,
+                      type: "single-param",
+                      data: { iriPrefix: config.defaultBaseIri },
+                    });
                   }
                 }
               }}
@@ -197,6 +203,24 @@ const TransformationSelector: React.FC<Props> = ({
                   ))}
                 </Select>
               </FormControl>
+            </HintWrapper>
+          </div>
+        )}
+        {selectedTransformation && selectedTransformation.type === "single-param" && (
+          <div className={styles.indent}>
+            <HintWrapper hint="Provide the parameter for the refinement.">
+              <TextField
+                label="Prefix"
+                value={selectedTransformation.data.iriPrefix}
+                onChange={(event) =>
+                  onTransformationChange({
+                    ...selectedTransformation,
+                    data: { iriPrefix: event.target.value.trim() },
+                  })
+                }
+                InputLabelProps={{ shrink: true }}
+                fullWidth
+              />
             </HintWrapper>
           </div>
         )}

--- a/src/containers/Publish/index.tsx
+++ b/src/containers/Publish/index.tsx
@@ -51,7 +51,14 @@ const Publish: React.FC<Props> = ({}) => {
                     // Rows might have been added, refer back to the original CSV
                     parsedCsv[rowIdx][column.columnRefinement.data.secondColumnIdx]
                   );
+                } else if (refinement?.type === "single-param" && column.columnRefinement.type === "single-param") {
+                  toInject = refinement.transformation(
+                    row[columnIdx],
+                    // Rows might have been added, refer back to the original CSV
+                    column.columnRefinement.data.iriPrefix
+                  );
                 }
+                // || column.columnRefinement.type === "single-param"
               }
               return new Array(...row.slice(0, columnIdx + 1), (await toInject) || "", ...row.slice(columnIdx + 1));
             })
@@ -61,6 +68,7 @@ const Publish: React.FC<Props> = ({}) => {
       }
       // Transformation
       if (parsedCsv) {
+        // Transformation done here for double-column single-param etc
         const transformationResult = await wizardAppConfig.applyTransformation({
           config: transformationConfig,
           source: tempRefinedCsv || parsedCsv,

--- a/types/WizardConfig.d.ts
+++ b/types/WizardConfig.d.ts
@@ -7,7 +7,7 @@ export declare type TriplyDbReference = {
   label: string;
   link: string;
 };
-export declare type ColumnRefinementType = "single" | "double-column";
+export declare type ColumnRefinementType = "single" | "double-column" | "single-param";
 export interface BaseColumnRefinement {
   label: string;
   description: string;
@@ -22,7 +22,11 @@ export interface DoubleColumnRefinement extends BaseColumnRefinement {
   type: "double-column";
   transformation: (firstColumn: string, selectedColumn: string) => Promise<string | undefined>;
 }
-export declare type ColumnRefinement = SingleColumnRefinement | DoubleColumnRefinement;
+export interface SingleColumnParamRefinement extends BaseColumnRefinement {
+  type: "single-param";
+  transformation: (value: string, iriPrefix: string) => Promise<string | undefined>;
+}
+export type ColumnRefinement = SingleColumnRefinement | DoubleColumnRefinement | SingleColumnParamRefinement;
 export default interface WizardConfig {
   appName?: string;
   dataplatformLink?: string;


### PR DESCRIPTION
Hi @GerwinBosch , after fixing the autocomplete to work with SPARQL we now added a new `single-param` type which allow devs to create a new columnRefinment function that takes 2 args: the column row value (as usual), and any string (a bit like `to-iri`)

That allows to create much more flexible refinement functions!

E.g. if you want to create a refinement to process a CSV with true/false values in a column, and you want to generate a specific URI when true. The user just need to pass the URI that will be generated if true


Note that this pull request also includes the commits to solve the issues with SPARQL autocomplete (cf. previous pull request), since I needed them to test the whole thing on our infrastructure

You can find an example of this feature deployed in production here: https://humanities.wizard.semanticscience.org